### PR TITLE
ダウンサンプリング調整

### DIFF
--- a/poc1/edge/app/repository/batch_repository.py
+++ b/poc1/edge/app/repository/batch_repository.py
@@ -3,10 +3,12 @@ from minio.error import S3Error
 from db import SessionLocal
 from sqlalchemy import text
 import os, tempfile
+import open3d as o3d  # 追加（既に記載済みならそのまま）
 
 CLOUD_OBJECT_EXT = os.getenv("CLOUD_OBJECT_EXT", ".ply")
 LOCAL_BUCKET = "local-point-cloud"
 CLOUD_BUCKET = "cloud-point-cloud"
+VOXEL = 0.1
 
 class BatchRepository:
   def __init__(self, mc: Minio, mc_cloud: Minio):
@@ -14,14 +16,12 @@ class BatchRepository:
     self.mc_cloud = mc_cloud
   
   def local_latest_key(self, geohash: str) -> str:
-    # 既存のレイアウトに合わせる
     return f"{geohash}/latest/latest.ply"
   
   def cloud_tmp_key(self, geohash: str) -> str:
     return f"tmp/{geohash}{CLOUD_OBJECT_EXT}"
   
   def ensure_bucket(self, client: Minio, bucket: str):
-    # バケットがなければ作成（競合は握りつぶし）
     try:
         if not client.bucket_exists(bucket):
             client.make_bucket(bucket)
@@ -49,17 +49,44 @@ class BatchRepository:
       src_key = self.local_latest_key(geohash)
       if self.stat_or_none(self.mc, LOCAL_BUCKET, src_key) is None:
           return False
-
-      # 一時DL → クラウドへ fput
-      with tempfile.NamedTemporaryFile(suffix=".ply", delete=False) as tf:
-          tmp = tf.name
+      
+      # 一時DL
+      with tempfile.NamedTemporaryFile(suffix=".ply", delete=False) as tf_in:
+        src_tmp = tf_in.name
+      # ダウンサンプリング後の書き出し先
+      with tempfile.NamedTemporaryFile(suffix=CLOUD_OBJECT_EXT, delete=False) as tf_out:
+        dst_tmp = tf_out.name
+        
       try:
-          self.mc.fget_object(LOCAL_BUCKET, src_key, tmp)
+          # MinIO から取得
+          self.mc.fget_object(LOCAL_BUCKET, src_key, src_tmp)
+          
+          # Open3Dで読み込み & ダウンサンプリング
+          pcd = o3d.io.read_point_cloud(src_tmp)
+          if pcd.is_empty():
+            print(f"[sync] skip empty point cloud: {src_key}")
+            return False
+          
+          # ダウンサンプリング（10cm）
+          pcd_ds = pcd.voxel_down_sample(VOXEL)
+
+          # バイナリPLYに書き出し
+          write_ok = o3d.io.write_point_cloud(dst_tmp, pcd_ds, write_ascii=False)
+          if not write_ok:
+            # 失敗時はオリジナルを送る
+            dst_tmp = src_tmp
+
+          # アップロード
           self.ensure_bucket(self.mc_cloud, CLOUD_BUCKET)
           dst_key = self.cloud_tmp_key(geohash)
-          self.mc_cloud.fput_object(CLOUD_BUCKET, dst_key, tmp, content_type="application/octet-stream")
-          print(f"[sync] uploaded {src_key} -> s3://{CLOUD_BUCKET}/{dst_key}")
+          self.mc_cloud.fput_object(CLOUD_BUCKET, dst_key, dst_tmp, content_type="application/octet-stream")
+          print(f"[sync] uploaded (downsampled) {src_key} -> s3://{CLOUD_BUCKET}/{dst_key}")
           return True
+
       finally:
-          try: os.remove(tmp)
-          except FileNotFoundError: pass
+          # 後片付け
+          for p in (src_tmp, dst_tmp):
+              try:
+                  os.remove(p)
+              except FileNotFoundError:
+                  pass

--- a/poc1/edge/app/repository/batch_repository.py
+++ b/poc1/edge/app/repository/batch_repository.py
@@ -8,7 +8,7 @@ import open3d as o3d  # 追加（既に記載済みならそのまま）
 CLOUD_OBJECT_EXT = os.getenv("CLOUD_OBJECT_EXT", ".ply")
 LOCAL_BUCKET = "local-point-cloud"
 CLOUD_BUCKET = "cloud-point-cloud"
-VOXEL = 0.1
+VOXEL = 0.15
 
 class BatchRepository:
   def __init__(self, mc: Minio, mc_cloud: Minio):

--- a/poc1/edge/app/usecase/aligmnent_usecase.py
+++ b/poc1/edge/app/usecase/aligmnent_usecase.py
@@ -10,7 +10,7 @@ from repository.alignment_repository import AlignmentRepository
 from db import SessionLocal      
 
 BUCKET = "local-point-cloud"   # バケット名（固定）
-VOXEL = 0.1                    # 10cm
+VOXEL = 0.03                   # 3cm
 DIST_RANSAC = VOXEL * 1.0      # RANSAC 対応距離（10cm）
 DIST_ICP    = VOXEL * 0.5      # ICP   対応距離（5cm）
 

--- a/poc1/edge/app/usecase/aligmnent_usecase.py
+++ b/poc1/edge/app/usecase/aligmnent_usecase.py
@@ -10,7 +10,7 @@ from repository.alignment_repository import AlignmentRepository
 from db import SessionLocal      
 
 BUCKET = "local-point-cloud"
-VOXEL = 0.03
+VOXEL = 0.1
 DIST_RANSAC = VOXEL * 1.0
 DIST_ICP    = VOXEL * 0.5
 

--- a/poc1/edge/app/usecase/aligmnent_usecase.py
+++ b/poc1/edge/app/usecase/aligmnent_usecase.py
@@ -9,10 +9,10 @@ from datetime import datetime, timezone
 from repository.alignment_repository import AlignmentRepository
 from db import SessionLocal      
 
-BUCKET = "local-point-cloud"   # バケット名（固定）
-VOXEL = 0.03                   # 3cm
-DIST_RANSAC = VOXEL * 1.0      # RANSAC 対応距離（10cm）
-DIST_ICP    = VOXEL * 0.5      # ICP   対応距離（5cm）
+BUCKET = "local-point-cloud"
+VOXEL = 0.03
+DIST_RANSAC = VOXEL * 1.0
+DIST_ICP    = VOXEL * 0.5
 
 
 def utc_ts():


### PR DESCRIPTION
## もとIssue
- https://github.com/yoyo1025/laboratory/issues/14
## 実装内容
- 大域モデル送信時にもダウンサンプリング
- ダウンサンプリングレートの調整
  - 局所モデル構築時: voxelサイズを3cmに設定
  - 大域モデル構築時: voxelサイズを10cmに設定
 ## 備考
元データ: 2.8MB
局所モデル・voxelサイズが10cm: 713.6KB
大域モデル・voxelサイズが15cm: 455.4KB
（大域モデル・voxelサイズが20cm: 314.4KB）